### PR TITLE
feat: 전체 직원 조회 api 구현 및 일부 코드 수정

### DIFF
--- a/src/main/java/graduate/schedule/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/graduate/schedule/common/response/status/BaseExceptionResponseStatus.java
@@ -52,7 +52,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
      */
     NOT_FOUND_MEMBER(5000, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 사용자입니다."),
     INVALID_PLATFORM(5001, HttpStatus.BAD_REQUEST.value(), "플랫폼 정보가 올바르지 않습니다."),
-    NOT_EXECUTIVE(5003, HttpStatus.BAD_REQUEST.value(), "가게의 사장 또는 매니저가 아닙니다."),
+    NOT_EXECUTIVE(5003, HttpStatus.BAD_REQUEST.value(), "가게 임원이 아닙니다.(권한 없음)"),
     NOT_STORE_MEMBER(5003, HttpStatus.BAD_REQUEST.value(), "가게 구성원이 아닙니다."),
 
     /**

--- a/src/main/java/graduate/schedule/controller/ExecutiveController.java
+++ b/src/main/java/graduate/schedule/controller/ExecutiveController.java
@@ -1,0 +1,31 @@
+package graduate.schedule.controller;
+
+import graduate.schedule.annotation.MemberId;
+import graduate.schedule.common.response.BaseResponse;
+import graduate.schedule.domain.member.Member;
+import graduate.schedule.dto.web.response.StoreAllEmployeeResponseDTO;
+import graduate.schedule.service.ExecutiveService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/executive") /* 고용인 기능 */
+public class ExecutiveController {
+    private final ExecutiveService executiveService;
+
+    /**
+    * @apiNote 전체 직원 조회 api
+    */
+    @GetMapping("/{storeId}/employee")
+    public BaseResponse<StoreAllEmployeeResponseDTO> getAllEmployees(@MemberId @Valid Member member, @PathVariable @Valid Long storeId) {
+        StoreAllEmployeeResponseDTO response = executiveService.getAllEmployees(member, storeId);
+        return new BaseResponse<>(response);
+    }
+}

--- a/src/main/java/graduate/schedule/controller/StoreController.java
+++ b/src/main/java/graduate/schedule/controller/StoreController.java
@@ -75,7 +75,7 @@ public class StoreController {
     }
 
     /**
-     * @apiNote 특정 달의 근무 가능한 시간 조회 api
+     * @apiNote 특정 멤버의 특정 달에 근무 가능한 시간 조회 api
      * */
     @GetMapping("/{storeId}/available-schedule/{searchMonth}")
     public BaseResponse<AvailableScheduleOnMonthResponseDTO> getAvailableScheduleOnMonth(@MemberId @Valid Member member, @PathVariable @Valid Long storeId, @PathVariable @Valid String searchMonth) {

--- a/src/main/java/graduate/schedule/dto/store/EmployeeDTO.java
+++ b/src/main/java/graduate/schedule/dto/store/EmployeeDTO.java
@@ -1,0 +1,12 @@
+package graduate.schedule.dto.store;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmployeeDTO {
+    private String name;
+    private Long memberId;
+    private String memberGrade;
+}

--- a/src/main/java/graduate/schedule/dto/web/response/StoreAllEmployeeResponseDTO.java
+++ b/src/main/java/graduate/schedule/dto/web/response/StoreAllEmployeeResponseDTO.java
@@ -1,0 +1,13 @@
+package graduate.schedule.dto.web.response;
+
+import graduate.schedule.dto.store.EmployeeDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class StoreAllEmployeeResponseDTO {
+    private List<EmployeeDTO> employees;
+}

--- a/src/main/java/graduate/schedule/repository/StoreMemberRepository.java
+++ b/src/main/java/graduate/schedule/repository/StoreMemberRepository.java
@@ -4,6 +4,7 @@ import graduate.schedule.domain.member.Member;
 import graduate.schedule.domain.store.Store;
 import graduate.schedule.domain.store.StoreMember;
 import graduate.schedule.dto.store.MyStoreDTO;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -31,4 +32,7 @@ public interface StoreMemberRepository extends JpaRepository<StoreMember, Long> 
     Boolean isExecutive(@Param("member") Member member, @Param("store") Store store);
 
     Optional<StoreMember> findByStoreAndMember(@Param("store") Store store, @Param("member") Member member);
+
+    @EntityGraph(attributePaths = {"member"})
+    List<StoreMember> findByStore(@Param("store") Store store);
 }

--- a/src/main/java/graduate/schedule/repository/StoreMemberWorkingTimeRepository.java
+++ b/src/main/java/graduate/schedule/repository/StoreMemberWorkingTimeRepository.java
@@ -15,7 +15,7 @@ public interface StoreMemberWorkingTimeRepository extends JpaRepository<StoreMem
             "join smwt.store s on s=:store " +
             "where FUNCTION('DATE_FORMAT', smwt.date, '%Y-%m')=:searchMonth " +
             "order by smwt.date")
-    List<Date> findDatesByStoreAndMonth(@Param("store") Store store, @Param("searchMonth") String searchMonth);
+    List<Date> findDatesByStoreAndMonthOrderByDate(@Param("store") Store store, @Param("searchMonth") String searchMonth);
 
     @EntityGraph(attributePaths = {"member"})
     List<StoreMemberWorkingTime> findSchedulesByStoreAndDate(Store store, Date date);

--- a/src/main/java/graduate/schedule/service/ExecutiveService.java
+++ b/src/main/java/graduate/schedule/service/ExecutiveService.java
@@ -1,0 +1,43 @@
+package graduate.schedule.service;
+
+import graduate.schedule.common.exception.MemberException;
+import graduate.schedule.common.exception.StoreException;
+import graduate.schedule.domain.member.Member;
+import graduate.schedule.domain.store.Store;
+import graduate.schedule.domain.store.StoreMember;
+import graduate.schedule.dto.store.EmployeeDTO;
+import graduate.schedule.dto.web.response.StoreAllEmployeeResponseDTO;
+import graduate.schedule.repository.StoreMemberRepository;
+import graduate.schedule.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static graduate.schedule.common.response.status.BaseExceptionResponseStatus.NOT_FOUND_STORE;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ExecutiveService {
+    private final StoreRepository storeRepository;
+    private final StoreMemberRepository storeMemberRepository;
+
+    public StoreAllEmployeeResponseDTO getAllEmployees(Member member, Long storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(NOT_FOUND_STORE));
+
+        List<StoreMember> storeMembers = storeMemberRepository.findByStore(store);
+        List<EmployeeDTO> employees = storeMembers.stream()
+                .map(storeMember -> new EmployeeDTO(
+                        storeMember.getMember().getName(),
+                        storeMember.getMember().getId(),
+                        storeMember.getMemberGrade().getGrade()
+                )).toList();
+        return new StoreAllEmployeeResponseDTO(employees);
+    }
+
+}

--- a/src/main/java/graduate/schedule/service/StoreService.java
+++ b/src/main/java/graduate/schedule/service/StoreService.java
@@ -222,7 +222,8 @@ public class StoreService {
                         time.getId(),
                         timeDeleteSeconds(time.getAvailableStartTime()),
                         timeDeleteSeconds(time.getAvailableEndTime())
-                )).toList();
+                ))
+                .sorted(Comparator.comparing(AvailableTimeInDayDTO::getStartTime)).toList();
 
         return new AvailableScheduleInDayDTO(
                 date,

--- a/src/main/java/graduate/schedule/service/StoreService.java
+++ b/src/main/java/graduate/schedule/service/StoreService.java
@@ -168,7 +168,7 @@ public class StoreService {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new StoreException(NOT_FOUND_STORE));
 
-        List<Date> existingWorkingDatesOnMonth = storeMemberWorkingTimeRepository.findDatesByStoreAndMonth(store, searchMonth);
+        List<Date> existingWorkingDatesOnMonth = storeMemberWorkingTimeRepository.findDatesByStoreAndMonthOrderByDate(store, searchMonth);
         List<WorkScheduleOnDayDTO> daySchedules = existingWorkingDatesOnMonth.stream()
                 .map(date -> getDateSchedule(store, member, date)).toList();
 


### PR DESCRIPTION
### 고용인 제한 기능
- 전체 직원 조회 api 구현
![image](https://github.com/KU-graduation-project-24-1/Schedule-Backend/assets/96233738/586f00be-404f-4fcb-9a40-c7984f81bb1f)


### 레파지토리 메서드명 수정
- findDatesByStoreAndMonth -> findDatesByStoreAndMonthOrderByDate 
### 특정 멤버의 가능한 근무 시간 조회시 정렬 추가
- 기존: 날짜순 정렬
- 추가: 각 날짜에 여러 시간이 존재할 경우, 시작 시간 순으로 정렬